### PR TITLE
Allow quotes around URL-type sources

### DIFF
--- a/bin/wkhtmltoimage-proxy
+++ b/bin/wkhtmltoimage-proxy
@@ -9,6 +9,5 @@ if executable.empty?
 end
 
 arguments = $*.map { |arg| arg.include?(' ') ? %Q("#{arg}") : arg }
-puts executable + " " + arguments.join(" ")
 
-#system(executable + " " + arguments.join(" "))
+system(executable + " " + arguments.join(" "))

--- a/bin/wkhtmltoimage-proxy
+++ b/bin/wkhtmltoimage-proxy
@@ -7,7 +7,7 @@ executable = `which wkhtmltoimage`.chomp
 if executable.empty?
   executable = File.join(File.dirname(__FILE__), WkhtmlImageExecutable.new.binary_wkhtmltoimage)
 end
-
+print "Ruby args: " + $*
 arguments = $*.map { |arg| arg.include?(' ') ? %Q("#{arg}") : arg }
-
-system(executable + " " + arguments.join(" "))
+print "Parsed args: " + executable + " " + arguments.join(" ")
+#system(executable + " " + arguments.join(" "))

--- a/bin/wkhtmltoimage-proxy
+++ b/bin/wkhtmltoimage-proxy
@@ -7,7 +7,8 @@ executable = `which wkhtmltoimage`.chomp
 if executable.empty?
   executable = File.join(File.dirname(__FILE__), WkhtmlImageExecutable.new.binary_wkhtmltoimage)
 end
-print "Ruby args: " + $*
+puts "Ruby args: "
+puts $*
 arguments = $*.map { |arg| arg.include?(' ') ? %Q("#{arg}") : arg }
-print "Parsed args: " + executable + " " + arguments.join(" ")
+puts "Parsed args: " + executable + " " + arguments.join(" ")
 #system(executable + " " + arguments.join(" "))

--- a/bin/wkhtmltoimage-proxy
+++ b/bin/wkhtmltoimage-proxy
@@ -9,5 +9,6 @@ if executable.empty?
 end
 
 arguments = $*.map { |arg| arg.include?(' ') ? %Q("#{arg}") : arg }
+print executable + " " + arguments.join(" ")
 
-system(executable + " " + arguments.join(" "))
+#system(executable + " " + arguments.join(" "))

--- a/bin/wkhtmltoimage-proxy
+++ b/bin/wkhtmltoimage-proxy
@@ -7,8 +7,7 @@ executable = `which wkhtmltoimage`.chomp
 if executable.empty?
   executable = File.join(File.dirname(__FILE__), WkhtmlImageExecutable.new.binary_wkhtmltoimage)
 end
-puts "Ruby args: "
-puts $*
+
 arguments = $*.map { |arg| arg.include?(' ') ? %Q("#{arg}") : arg }
-puts "Parsed args: " + executable + " " + arguments.join(" ")
-#system(executable + " " + arguments.join(" "))
+
+system(executable + " " + arguments.join(" "))

--- a/bin/wkhtmltoimage-proxy
+++ b/bin/wkhtmltoimage-proxy
@@ -9,6 +9,6 @@ if executable.empty?
 end
 
 arguments = $*.map { |arg| arg.include?(' ') ? %Q("#{arg}") : arg }
-print executable + " " + arguments.join(" ")
+puts executable + " " + arguments.join(" ")
 
 #system(executable + " " + arguments.join(" "))

--- a/lib/websnap/source.rb
+++ b/lib/websnap/source.rb
@@ -7,7 +7,7 @@ module WebSnap
     end
     
     def url?
-      @source.is_a?(String) && @source.match(/^http/)
+      @source.is_a?(String) && @source.match(/^(http)|^(\"http)|^(\'http)/)
     end
     
     def file?

--- a/lib/websnap/source.rb
+++ b/lib/websnap/source.rb
@@ -7,7 +7,7 @@ module WebSnap
     end
     
     def url?
-      @source.is_a?(String) && @source.match(/^(http)|^(\"http)|^(\'http)/)
+      @source.is_a?(String) && @source.match(/^((\'|\")*http)/)
     end
     
     def file?

--- a/spec/source_spec.rb
+++ b/spec/source_spec.rb
@@ -8,6 +8,21 @@ describe WebSnap::Source do
       source.should be_url
     end
     
+    it "should return true if passed a url like a single-quoted string" do
+      source = WebSnap::Source.new("'http://google.com'")
+      source.should be_url
+    end
+    
+    it "should return true if passed a url like a double-quoted string" do
+      source = WebSnap::Source.new("\"http://google.com\"")
+      source.should be_url
+    end
+    
+    it "should return true if passed a url like a double-quoted and single-quoted string" do
+      source = WebSnap::Source.new("\"'http://google.com'\"")
+      source.should be_url
+    end
+    
     it "should return false if passed a file" do
       source = WebSnap::Source.new(File.new(__FILE__))
       source.should_not be_url


### PR DESCRIPTION
wkhtmltoimage fails on urls that have '&' in the query string (and I think in other cases as well, I need to check further) unless the url is quoted in the wkhtmltoimage command. I modified lib/websnap/source.rb to allow this. However, the way websnap currently works you have to put two explicit quotes around the url for it to come out quoted when the actual command is run, like so:

snap = WebSnap::Snapper.new("\"\'"+url+"\'\"")

This is obviously kind of clunky, so I think websnap should automatically add these quotes to url sources, but I haven't tested enough to see if there would be any negative repercussions for this. I plan to make the change to automatically quote url sources and do a future pull request for it.
